### PR TITLE
Fix blank post pages caused by trailing slash mismatch

### DIFF
--- a/app/pages/posts/[slug].vue
+++ b/app/pages/posts/[slug].vue
@@ -4,13 +4,17 @@ import { enUS } from 'date-fns/locale';
 import { joinURL } from 'ufo';
 
 const route = useRoute();
+// Normalize path: strip trailing slash to match prerendered payload keys.
+// GitHub Pages 301-redirects to trailing-slash URLs, causing a mismatch
+// between the prerendered key (/posts/slug) and client path (/posts/slug/).
+const path = route.path.replace(/\/+$/, '') || '/';
 
-const { data: post } = await useAsyncData(route.path, () => queryCollection('posts').path(route.path).first());
+const { data: post } = await useAsyncData(path, () => queryCollection('posts').path(path).first());
 if (!post.value) {
   throw createError({ statusCode: 404, statusMessage: 'Post not found', fatal: true });
 }
 
-const { data: surround } = await useAsyncData(`${route.path}-surround`, () => queryCollectionItemSurroundings('posts', route.path), { default: () => [] });
+const { data: surround } = await useAsyncData(`${path}-surround`, () => queryCollectionItemSurroundings('posts', path), { default: () => [] });
 
 const title = post.value.title;
 const description = post.value.description;


### PR DESCRIPTION
## Summary

- Post pages render as blank (header/footer only) after hydration because `useAsyncData` payload keys don't match between server and client
- Root cause: GitHub Pages 301-redirects to add trailing slashes (`/posts/slug` → `/posts/slug/`), so the client's `route.path` differs from the prerendered payload key
- Fix: normalize `route.path` by stripping trailing slashes before using it as the `useAsyncData` key and `queryCollection` path

## Detail

During `nuxt generate`, payload data is stored under `/posts/slug` (no trailing slash). At browse time, GitHub Pages redirects to `/posts/slug/` (with slash). During hydration, `useAsyncData` looks up `/posts/slug/` in the payload, finds no match, returns null, and the `throw createError(404)` fires — silently replacing pre-rendered content with the error page.

## Test plan

- [ ] Direct page load with trailing slash shows article content
- [ ] Direct page load without trailing slash shows article content
- [ ] Client-side navigation from homepage to a post shows article content
- [ ] Verified with Playwright headless tests across multiple posts