### PR TITLE
Fix Lighthouse audit failures on post pages + restore report artifact upload

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           name: lighthouse-reports
           path: .lighthouseci/
+          # .lighthouseci is a dot-directory; upload-artifact@v4 skips hidden
+          # files by default, which previously uploaded nothing ("No files
+          # were found with the provided path: .lighthouseci/").
+          include-hidden-files: true
           if-no-files-found: warn
           retention-days: 14
         if: always()

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -31,7 +31,7 @@ const links = [
         label="Blog"
         color="info"
         variant="subtle"
-        class="mb-0.5 dark:bg-midnight-700 dark:text-midnight-300"
+        class="mb-0.5 text-info-700 dark:bg-midnight-700 dark:text-midnight-300"
       />
     </template>
 

--- a/app/pages/posts/[slug].vue
+++ b/app/pages/posts/[slug].vue
@@ -75,6 +75,8 @@ else {
           <NuxtImg
             :src="post.image.src"
             :alt="post.image.alt || post.title"
+            :width="post.image.width"
+            :height="post.image.height"
             class="w-full h-auto rounded-lg shadow-sm"
             loading="lazy"
           />

--- a/content.config.ts
+++ b/content.config.ts
@@ -27,6 +27,10 @@ export default defineContentConfig({
         image: z.object({
           src: z.string(),
           alt: z.string().optional(),
+          // Intrinsic dimensions let the hero <NuxtImg> reserve space,
+          // avoiding layout shift (CLS) and the "unsized-images" audit.
+          width: z.number().optional(),
+          height: z.number().optional(),
         }).optional(),
         badge: z.object({
           label: z.string(),

--- a/content/posts/2024-09-05-constraints.md
+++ b/content/posts/2024-09-05-constraints.md
@@ -9,6 +9,8 @@ authors:
       src: /img/portrait-profile-pic-delano-2025-m.png
 image:
   src: /img/blog/2024/2024-0905-data-privacy-framework-claude.svg
+  width: 800
+  height: 400
 badge:
   label: Privacy
 readingTime: 6


### PR DESCRIPTION
## Summary

Resolves the `Lighthouse Audit` CI failure (tracked in #11). The job audits two URLs — the homepage and `/posts/2024-09-05-constraints/` (a canary post) — and the post page was failing **three `error`-level assertions**. All were template/theme-level, not content.

I pulled the exact failing nodes from a local Lighthouse run rather than guessing, then fixed each at its source.

## The failures and fixes

| Audit | Before | Root cause | Fix |
|---|---|---|---|
| `color-contrast` | **0** | Header **"Blog" `UBadge`** (`color="info"`, `subtle`): `#2b7fff` on `#eaf2ff` = **3.33:1** in light mode | Darken the light-mode label to `text-info-700` (dark-mode override already passed) |
| `unsized-images` | **0.5** | Hero `<NuxtImg>` had no `width`/`height`, so it reserved no space | Add optional `width`/`height` to the posts `image` schema, bind them in the post template, set the canary post's intrinsic size **800×400** |
| `cumulative-layout-shift` | **0.155** | The unsized hero shifting content as it loads | Resolved by reserving the hero's space (above) |

### Plus: restore the report artifact upload
The "Upload Lighthouse reports" step was silently uploading nothing — `actions/upload-artifact@v4` skips hidden files by default, and `.lighthouseci/` is a dot-directory (`No files were found with the provided path: .lighthouseci/`). Added `include-hidden-files: true` so the HTML/JSON reports are retained for future diagnosis.

## Verification

Generated the static site and ran Lighthouse locally on both audited URLs:

| | color-contrast | unsized-images | CLS | a11y category |
|---|---|---|---|---|
| Homepage | 1 ✅ | 1 ✅ | 0 ✅ | 1.0 |
| Constraints post | 1 ✅ | 1 ✅ | 0 ✅ | 1.0 |

All `error`-level assertions now pass on both pages. The remaining `categories:performance` shortfall (~0.79–0.82 vs 0.85) is a **`warn`**, not a gate — inherent to the Nuxt UI Pro bundle under throttled mobile, and left as-is.

`pnpm typecheck` and `pnpm check:content` pass; the changed files lint clean. (The 44 pre-existing ESLint errors in `scripts/check-content.js` are untouched by this PR.)

## Notes / follow-ups
- The `image.width`/`height` fields are a **reusable mechanism** — other posts can adopt them for the same CLS/`unsized-images` benefit (the template degrades gracefully when they're absent). Only the audited canary post is populated here to keep the change focused.
- The contrast fix is scoped to the one failing badge rather than a global `--ui-info` override, mirroring the existing `--ui-primary` light-mode override but with lower blast radius.

Closes #11.

https://claude.ai/code/session_01XZr4ojD3VnLu5cYLh7w9YS

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZr4ojD3VnLu5cYLh7w9YS)_