### PR TITLE
Self-host fonts: restrict @nuxt/fonts to the local provider (no third-party font fetching)

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -59,6 +59,16 @@ export default defineNuxtConfig({
     provider: 'ipx',
   },
 
+  // Privacy: never contact third-party font providers (Google Fonts, Bunny,
+  // Fontshare, Fontsource, Google icons). @nuxt/ui bundles @nuxt/fonts, which
+  // would otherwise probe those at build time. Restricting to the `local`
+  // provider disables every remote provider. Our only custom font (Zilla Slab)
+  // is self-hosted via app/assets/css/font.css; everything else uses system
+  // font stacks, so nothing depends on a remote provider.
+  fonts: {
+    provider: 'local',
+  },
+
   vite: {
     server: {
       allowedHosts:


### PR DESCRIPTION
## Problem

`@nuxt/ui` (v3) bundles `@nuxt/fonts`, which initializes its remote font providers — **Google Fonts, Bunny, Fontshare, Fontsource, Google icons** — and probes their APIs at build time. In this repo that surfaces as errors in the build log:

```
ERROR Could not initialize provider google ... [GET] "https://fonts.google.com/metadata/fonts": 403 Forbidden
ERROR Could not initialize provider fontshare ... 403 Forbidden
ERROR Could not initialize provider bunny ... 403 Forbidden
ERROR Could not initialize provider googleicons ... 403 Forbidden
Could not initialize provider `fontsource` ... 403 Forbidden
```

For a privacy product, the build should not contact third-party font services at all. (The requests are blocked in our sandbox, but in a networked CI/production build they succeed.)

## Fix

Set `fonts.provider: 'local'` in `nuxt.config.ts`. Per `fontless`' `resolveProviders`, a single configured `provider` causes **every other provider to be deleted before initialization** (`if (options.provider && options.provider !== key) delete providers[key]`), so no remote provider is ever contacted.

Nothing depends on the remote providers:
- The only custom font, **Zilla Slab**, is already self-hosted via `app/assets/css/font.css` (`@font-face` → committed `app/assets/css/fonts/zs/*.woff2`).
- Everything else uses system font stacks.

## Verification (fresh `pnpm generate`)

- ✅ **Zero** remote font providers initialized (previously 5 attempted + 403'd)
- ✅ Site builds successfully
- ✅ Zilla Slab still served **same-domain** (`/_nuxt/ZillaSlab-*.woff2`)
- ✅ No third-party font URLs anywhere in `.output/public`
- ✅ `pnpm typecheck` passes

## Scope
- One-line config change (10 lines incl. an explanatory comment). No runtime/visual change — fonts render exactly as before, just without the build-time third-party calls.
- The pre-existing `node/prefer-global/process` ESLint note in `nuxt.config.ts` is unrelated and left untouched.

https://claude.ai/code/session_01XZr4ojD3VnLu5cYLh7w9YS

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZr4ojD3VnLu5cYLh7w9YS)_